### PR TITLE
Change to supply Fedora version as parameter instead of hard-code fixed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose -f fcrepo-postgres.yml up -
 docker-compose -f fcrepo-postgres.yml down
 ```
 
+# Rebuild the docker image and start the Fedora (e.g. 5.0.0) server
+```
+FEDORA_VERSION=5.0.0 FEDORA_TAG=5.0.0 docker-compose up -d --force-recreate --build
+```
+
 Fedora [Dockerfile](docker/services/fcrepo/Dockerfile)
 
 You can shell into the machine with `docker exec -i -t "CONTAINER ID" /bin/bash`

--- a/README.md
+++ b/README.md
@@ -7,28 +7,28 @@ This is the Git repo of the Docker image for [Fedora 5 docker](https://hub.docke
 * [Docker](https://www.docker.com/)
 
 ## Usage
-Run Fedora with a file-based objects database (Default Fcrepo 5.0.0):
+Run Fedora with a file-based objects database:
 ```
-# Start server
-docker-compose up -d
+# Start Fedora(e.g. 5.0.2) server
+FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose up -d
 
 # Shutdown server
 docker-compose down
 ```
 
-Run Fedora with a MySQL database:
+Run Fedora(e.g. 5.0.2) with a MySQL database:
 ```
 # Start server
-docker-compose -f fcrepo-mysql.yml up -d
+FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose -f fcrepo-mysql.yml up -d
 
 # Shutdown server
 docker-compose -f fcrepo-mysql.yml down
 ```
 
-Run Fedora with a PostgreSQL database:
+Run Fedora(e.g. 5.0.2) with a PostgreSQL database:
 ```
 # Start server
-docker-compose -f fcrepo-postgres.yml up -d
+FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose -f fcrepo-postgres.yml up -d
 
 # Shutdown server
 docker-compose -f fcrepo-postgres.yml down
@@ -38,12 +38,12 @@ Fedora [Dockerfile](docker/services/fcrepo/Dockerfile)
 
 You can shell into the machine with `docker exec -i -t "CONTAINER ID" /bin/bash`
 
-## In this Docker image, see detail in [Dockerfile](Dockerfile)
+## In this Docker image, see detail in [Dockerfile](docker/services/fcrepo/Dockerfile)
 
-* Ubuntu 14.04 64-bit machine with: 
   * [Tomcat 8.0.53](https://tomcat.apache.org) at [http://localhost:8080](http://localhost:8080)
     * Manager username = "fedora4", password = "fedora4"
   * [Fedora 5.0.0](https://wiki.duraspace.org/display/FF/Downloads) at [http://localhost:8080/fcrepo](http://localhost:8080/fcrepo)
+    * username = "fedoraAdmin", password = "secret3"
 
   ps. MacOS: docker is configured to use the default machine with IP e.g. 192.168.99.100 or 127.0.0.1, the Fedora 4 URL is either [http://192.168.99.100:8080/fcrepo](http://192.168.99.100:8080/fcrepo) or [http://127.0.0.1/fcrepo](http://127.0.0.1/fcrepo). You can use "docker-machine ip" to see your docker machine IP.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the Git repo of the Docker image for [Fedora 5 docker](https://hub.docke
 Run Fedora with a file-based objects database:
 ```
 # Start Fedora(e.g. 5.0.2) server
-FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose up -d
+FEDORA_TAG=5.0.2 docker-compose up -d
 
 # Shutdown server
 docker-compose down
@@ -19,7 +19,7 @@ docker-compose down
 Run Fedora(e.g. 5.0.2) with a MySQL database:
 ```
 # Start server
-FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose -f fcrepo-mysql.yml up -d
+FEDORA_TAG=5.0.2 docker-compose -f fcrepo-mysql.yml up -d
 
 # Shutdown server
 docker-compose -f fcrepo-mysql.yml down
@@ -28,7 +28,7 @@ docker-compose -f fcrepo-mysql.yml down
 Run Fedora(e.g. 5.0.2) with a PostgreSQL database:
 ```
 # Start server
-FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose -f fcrepo-postgres.yml up -d
+FEDORA_TAG=5.0.2 docker-compose -f fcrepo-postgres.yml up -d
 
 # Shutdown server
 docker-compose -f fcrepo-postgres.yml down
@@ -36,7 +36,7 @@ docker-compose -f fcrepo-postgres.yml down
 
 # Rebuild the docker image and start the Fedora (e.g. 5.0.0) server
 ```
-FEDORA_VERSION=5.0.0 FEDORA_TAG=5.0.0 docker-compose up -d --force-recreate --build
+FEDORA_TAG=5.0.0 docker-compose up -d --force-recreate --build
 ```
 
 Fedora [Dockerfile](docker/services/fcrepo/Dockerfile)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     build:
       context: ./docker/services/fcrepo
       args:
-        FEDORA_VERSION: 5.0.0
-        FEDORA_TAG: 5.0.0
+        FEDORA_VERSION: ${FEDORA_VERSION}
+        FEDORA_TAG: ${FEDORA_TAG}
     image: fcrepo
     networks:
       appnetwork:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     build:
       context: ./docker/services/fcrepo
       args:
-        FEDORA_VERSION: ${FEDORA_VERSION}
         FEDORA_TAG: ${FEDORA_TAG}
     image: fcrepo
     networks:

--- a/docker/services/fcrepo/Dockerfile
+++ b/docker/services/fcrepo/Dockerfile
@@ -5,8 +5,8 @@ MAINTAINER Yinlin Chen "ylchen@vt.edu"
 RUN apt-get update && apt-get -y upgrade
 
 # Install Fedora4
-ARG FEDORA_VERSION=5.0.0
-ARG FEDORA_TAG=5.0.0
+ARG FEDORA_VERSION=
+ARG FEDORA_TAG=
 ARG FedoraConfig=
 ARG ModeshapeConfig=file-simple
 ARG JDBCConfig=

--- a/docker/services/fcrepo/Dockerfile
+++ b/docker/services/fcrepo/Dockerfile
@@ -4,8 +4,7 @@ MAINTAINER Yinlin Chen "ylchen@vt.edu"
 
 RUN apt-get update && apt-get -y upgrade
 
-# Install Fedora4
-ARG FEDORA_VERSION=
+# Install Fedora 5
 ARG FEDORA_TAG=
 ARG FedoraConfig=
 ARG ModeshapeConfig=file-simple

--- a/docker/services/fcrepo/Dockerfile
+++ b/docker/services/fcrepo/Dockerfile
@@ -5,8 +5,8 @@ MAINTAINER Yinlin Chen "ylchen@vt.edu"
 RUN apt-get update && apt-get -y upgrade
 
 # Install Fedora4
-ARG FEDORA_VERSION=4.7.5
-ARG FEDORA_TAG=4.7.5
+ARG FEDORA_VERSION=5.0.0
+ARG FEDORA_TAG=5.0.0
 ARG FedoraConfig=
 ARG ModeshapeConfig=file-simple
 ARG JDBCConfig=

--- a/fcrepo-mysql.yml
+++ b/fcrepo-mysql.yml
@@ -10,7 +10,6 @@ services:
     build: 
       context: ./docker/services/fcrepo
       args:
-        FEDORA_VERSION: ${FEDORA_VERSION}
         FEDORA_TAG: ${FEDORA_TAG}
         ModeshapeConfig: jdbc-mysql
         JDBCConfig: -Dfcrepo.mysql.username=fcrepoadmin -Dfcrepo.mysql.password=fcrepoadminpw -Dfcrepo.mysql.host=mysql.docker.local -Dfcrepo.mysql.port=3306 

--- a/fcrepo-mysql.yml
+++ b/fcrepo-mysql.yml
@@ -10,8 +10,8 @@ services:
     build: 
       context: ./docker/services/fcrepo
       args:
-        FEDORA_VERSION: 5.0.0
-        FEDORA_TAG: 5.0.0
+        FEDORA_VERSION: ${FEDORA_VERSION}
+        FEDORA_TAG: ${FEDORA_TAG}
         ModeshapeConfig: jdbc-mysql
         JDBCConfig: -Dfcrepo.mysql.username=fcrepoadmin -Dfcrepo.mysql.password=fcrepoadminpw -Dfcrepo.mysql.host=mysql.docker.local -Dfcrepo.mysql.port=3306 
     image: fcrepo

--- a/fcrepo-postgres.yml
+++ b/fcrepo-postgres.yml
@@ -10,8 +10,8 @@ services:
     build: 
       context: ./docker/services/fcrepo
       args:
-        FEDORA_VERSION: 5.0.0
-        FEDORA_TAG: 5.0.0
+        FEDORA_VERSION: ${FEDORA_VERSION}
+        FEDORA_TAG: ${FEDORA_TAG}
         ModeshapeConfig: jdbc-postgresql
         JDBCConfig: -Dfcrepo.postgresql.username=fcrepoadmin -Dfcrepo.postgresql.password=fcrepoadminpw -Dfcrepo.postgresql.host=postgres.docker.local -Dfcrepo.postgresql.port=5432 
     image: fcrepo

--- a/fcrepo-postgres.yml
+++ b/fcrepo-postgres.yml
@@ -10,7 +10,6 @@ services:
     build: 
       context: ./docker/services/fcrepo
       args:
-        FEDORA_VERSION: ${FEDORA_VERSION}
         FEDORA_TAG: ${FEDORA_TAG}
         ModeshapeConfig: jdbc-postgresql
         JDBCConfig: -Dfcrepo.postgresql.username=fcrepoadmin -Dfcrepo.postgresql.password=fcrepoadminpw -Dfcrepo.postgresql.host=postgres.docker.local -Dfcrepo.postgresql.port=5432 


### PR DESCRIPTION
# What does this Pull Request do?
Change to supply Fedora version as parameter instead of hard-code fixed version

# How should this be tested?
Follow the new README.md and test all three

Run Fedora with a file-based objects database:
```
# Start server
FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose up -d

# Shutdown server
docker-compose down
```

Run Fedora with a MySQL database:
```
# Start server
FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose -f fcrepo-mysql.yml up -d

# Shutdown server
docker-compose -f fcrepo-mysql.yml down
```

Run Fedora with a PostgreSQL database:
```
# Start server
FEDORA_VERSION=5.0.2 FEDORA_TAG=5.0.2 docker-compose -f fcrepo-postgres.yml up -d

# Shutdown server
docker-compose -f fcrepo-postgres.yml down
```

Test the Fedora 5 through web browser.

# Interested parties
Tag (@fcrepo4-labs/committers ) 