### PR TITLE
Update examples to use 5.1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,44 +9,44 @@ This is the Git repo of the Docker image for [Fedora 5 docker](https://hub.docke
 ## Usage
 Run Fedora with a file-based objects database:
 ```
-# Start Fedora(e.g. 5.0.2) server
-FEDORA_TAG=5.0.2 docker-compose up -d
+# Start Fedora(e.g. 5.1.0) server
+FEDORA_TAG=5.1.0 docker-compose up -d
 
 # Shutdown server
 docker-compose down
 ```
 
-Run Fedora(e.g. 5.0.2) with a MySQL database:
+Run Fedora(e.g. 5.1.0) with a MySQL database:
 ```
 # Start server
-FEDORA_TAG=5.0.2 docker-compose -f fcrepo-mysql.yml up -d
+FEDORA_TAG=5.1.0 docker-compose -f fcrepo-mysql.yml up -d
 
 # Shutdown server
 docker-compose -f fcrepo-mysql.yml down
 ```
 
-Run Fedora(e.g. 5.0.2) with a PostgreSQL database:
+Run Fedora(e.g. 5.1.0) with a PostgreSQL database:
 ```
 # Start server
-FEDORA_TAG=5.0.2 docker-compose -f fcrepo-postgres.yml up -d
+FEDORA_TAG=5.1.0 docker-compose -f fcrepo-postgres.yml up -d
 
 # Shutdown server
 docker-compose -f fcrepo-postgres.yml down
 ```
 
-Run Fedora(e.g. 5.0.2) with Camel Toolbox customizations:
+Run Fedora(e.g. 5.1.0) with Camel Toolbox customizations:
 ```
 # Start server
-FEDORA_TAG=5.0.2 docker-compose -f fcrepo-camel.yml up -d
+FEDORA_TAG=5.1.0 docker-compose -f fcrepo-camel.yml up -d
 
 # Shutdown server
 docker-compose -f fcrepo-camel.yml down
 ```
  * See [Camel](docker/services/fcrepo-camel) section for details.
 
-# Rebuild the docker image and start the Fedora (e.g. 5.0.0) server
+# Rebuild the docker image and start the Fedora (e.g. 5.1.0) server
 ```
-FEDORA_TAG=5.0.0 docker-compose up -d --force-recreate --build
+FEDORA_TAG=5.1.0 docker-compose up -d --force-recreate --build
 ```
 Fedora [Dockerfile](docker/services/fcrepo/Dockerfile)
 
@@ -56,7 +56,7 @@ You can shell into the machine with `docker exec -i -t "CONTAINER ID" /bin/bash`
 
   * [Tomcat 8.0.53](https://tomcat.apache.org) at [http://localhost:8080](http://localhost:8080)
     * Manager username = "fedora4", password = "fedora4"
-  * [Fedora 5.0.0](https://wiki.duraspace.org/display/FF/Downloads) at [http://localhost:8080/fcrepo](http://localhost:8080/fcrepo)
+  * [Fedora 5.1.0](https://wiki.duraspace.org/display/FF/Downloads) at [http://localhost:8080/fcrepo](http://localhost:8080/fcrepo)
     * username = "fedoraAdmin", password = "secret3"
 
   ps. MacOS: docker is configured to use the default machine with IP e.g. 192.168.99.100 or 127.0.0.1, the Fedora 4 URL is either [http://192.168.99.100:8080/fcrepo](http://192.168.99.100:8080/fcrepo) or [http://127.0.0.1/fcrepo](http://127.0.0.1/fcrepo). You can use "docker-machine ip" to see your docker machine IP.

--- a/docker/services/fcrepo-camel/readme.md
+++ b/docker/services/fcrepo-camel/readme.md
@@ -20,7 +20,7 @@ The reindexing service has been configured to bind to the host, `0.0.0.0`, inste
 	git clone https://github.com/fcrepo4-labs/fcrepo4-docker.git
 	cd fcrepo4-docker
     # Start server
-    FEDORA_TAG=5.0.2 docker-compose -f fcrepo-camel.yml up -d
+    FEDORA_TAG=5.1.0 docker-compose -f fcrepo-camel.yml up -d
     # Shutdown server
     docker-compose -f fcrepo-camel.yml down
     ```

--- a/fcrepo-camel.yml
+++ b/fcrepo-camel.yml
@@ -6,12 +6,12 @@ networks:
 
 services:
   fcrepo:
-    container_name: fcrepo
+    container_name: fcrepo-camel
     build:
       context: ./docker/services/fcrepo-camel
       args:
         FEDORA_TAG: ${FEDORA_TAG}
-    image: fcrepo
+    image: fcrepo-camel
     networks:
       appnetwork:
         aliases:


### PR DESCRIPTION
Also use fcrepo-camel for container and image name in
matching compose file as it builds & runs a distinct image.